### PR TITLE
Datasource url template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: go
 before_install:
   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-
-cache:
-  directories:
-    - vendor

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -29,14 +29,22 @@ type Endpoint struct {
 	iamSession *session.Session
 }
 
-// Call the Endpoint with the provided query string and requestBody (if applicable)
-func (e *Endpoint) Call(subPath, query, requestBody string) (*APIResponse, error) {
+func (e *Endpoint) getUrl(subPath, query string) (*url.URL, error) {
 	u, err := url.Parse(e.URL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse URL: %s", e.URL)
 	}
 	u.Path = path.Join(u.Path, subPath)
 	u.RawQuery = query
+	return u, nil
+}
+
+// Call the Endpoint with the provided query string and requestBody (if applicable)
+func (e *Endpoint) Call(subPath, query, requestBody string) (*APIResponse, error) {
+	u, err := e.getUrl(subPath, query)
+	if err != nil {
+		return nil, fmt.Errorf("unable to build URL: %s", e.URL)
+	}
 	var body io.Reader
 	switch e.Method {
 	case http.MethodGet:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -31,7 +31,7 @@ type Endpoint struct {
 	iamSession *session.Session
 }
 
-func (e *Endpoint) getUrl(subPath, query string) (*url.URL, error) {
+func (e *Endpoint) GetUrl(subPath, query string) (*url.URL, error) {
 	tmpl, err := template.New("url").Funcs(map[string]interface{}{"env": os.Getenv}).Parse(e.URL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing url as template: %v", err)
@@ -54,7 +54,7 @@ func (e *Endpoint) getUrl(subPath, query string) (*url.URL, error) {
 
 // Call the Endpoint with the provided query string and requestBody (if applicable)
 func (e *Endpoint) Call(subPath, query, requestBody string) (*APIResponse, error) {
-	u, err := e.getUrl(subPath, query)
+	u, err := e.GetUrl(subPath, query)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build URL: %s", e.URL)
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -56,7 +56,7 @@ func (e *Endpoint) GetUrl(subPath, query string) (*url.URL, error) {
 func (e *Endpoint) Call(subPath, query, requestBody string) (*APIResponse, error) {
 	u, err := e.GetUrl(subPath, query)
 	if err != nil {
-		return nil, fmt.Errorf("unable to build URL: %s", e.URL)
+		return nil, fmt.Errorf("unable to build URL (%s): %v", e.URL, err)
 	}
 	var body io.Reader
 	switch e.Method {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -184,3 +184,17 @@ func TestIAMAuth(t *testing.T) {
 		t.Errorf("expected %s", expectedAuthz)
 	}
 }
+
+func TestEnvUrlTemplate(t *testing.T) {
+	e := &Endpoint{URL: "{{ env \"API_BASE\" }}/foo", Method: http.MethodGet}
+	apiBase := "https://api.local/v1/"
+	os.Setenv("API_BASE", apiBase)
+	u, err := e.getUrl("", "")
+	if err != nil {
+		t.Fatalf("Error getting url: %v", err)
+	}
+
+	if u.String() != "https://api.local/v1/foo" {
+		t.Errorf("Built wrong url: got '%s' expected '%s'", u.String(), "https://api.local/v1/foo")
+	}
+}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -189,7 +189,7 @@ func TestEnvUrlTemplate(t *testing.T) {
 	e := &Endpoint{URL: "{{ env \"API_BASE\" }}/foo", Method: http.MethodGet}
 	apiBase := "https://api.local/v1/"
 	os.Setenv("API_BASE", apiBase)
-	u, err := e.getUrl("", "")
+	u, err := e.GetUrl("", "")
 	if err != nil {
 		t.Fatalf("Error getting url: %v", err)
 	}

--- a/pkg/distromux/testing.go
+++ b/pkg/distromux/testing.go
@@ -33,7 +33,7 @@ func (m *MockDataSourceCall) mock(endpoints api.EndpointMap) (gock.Mock, error) 
 	if !ok {
 		return nil, fmt.Errorf("invalid datasource specified for mock: %s", m.DataSource)
 	}
-	u, err := url.Parse(source.URL)
+	u, err := source.GetUrl("", "")
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse datasource url %s: %v", m.DataSource, err)
 	}


### PR DESCRIPTION
Allow datasource urls to contain golang template code.  Add env function to that template environment for retrieving url components from environment variables.